### PR TITLE
removed lp__ column from Stan samples array

### DIFF
--- a/compareMCMCs/R/MCMCdef_stan.R
+++ b/compareMCMCs/R/MCMCdef_stan.R
@@ -107,6 +107,10 @@ MCMCdef_stan_impl <- function(MCMCinfo,
                                  # pars = monitorInfo$monitorVars,
                                  permuted = FALSE,
                                  inc_warmup = FALSE)[, 1, ]
+
+  ## Remove 'lp__' variable from Stan samples array
+  lpColumn <- which(colnames(samplesArray) == 'lp__')
+  samplesArray <- samplesArray[, -lpColumn]
   
   ## Stan provides its own timings, but there is a need
   ## to have them be comparable to those for other MCMCs.


### PR DESCRIPTION
@perrydv @salleuska This removes the `lp__` column from the Stan samples array.

At best, including this column in the results causes the `min_efficiency` and `max_efficiency` for Stan to be totally wrong.

At worst, including this column in the Stan samples causes `make_MCMC_comparison_pages` to fail.

This PR modifies the MCMCdef implementation for Stan, to remove this column of `lp__` samples.

