### PR TITLE
fix ordering of byParameter results

### DIFF
--- a/compareMCMCs/R/MCMCdef_dummy.R
+++ b/compareMCMCs/R/MCMCdef_dummy.R
@@ -19,9 +19,9 @@ MCMCdef_dummy_impl <- function(MCMCinfo,
     monitorInfo$monitorVars <- 'param'
   }
   dummy_results <- matrix(
-    stats::rnorm(length(monitorInfo$monitorVars) * MCMCcontrol$niter),
+    stats::rnorm(length(monitorInfo$monitors) * MCMCcontrol$niter),
     nrow = MCMCcontrol$niter,
-    dimnames = list(NULL, monitorInfo$monitorVars)
+    dimnames = list(NULL, monitorInfo$monitors)
   )
   dummytime <- 0.1
   dummytime[1:5] <- c(60, 60, 60, 0, 0)

--- a/compareMCMCs/R/MCMCresult.R
+++ b/compareMCMCs/R/MCMCresult.R
@@ -160,12 +160,16 @@ MCMCresult <- R6::R6Class(
    clearMetrics = function(byParameter = TRUE, byMCMC = TRUE) {
      if(byParameter) {
        params <- colnames(self$samples)
+       fparams <- factor(params, levels=params) # level=params avoids x[1], x[10],..., x[2], x[20], etc..
+       fMCMC <- factor(rep(self$MCMC, length(params)), levels=self$MCMC)
        self$metrics$byParameter <-
-           data.frame(MCMC = rep(self$MCMC, length(params)),
-                      Parameter = params)
+           data.frame(MCMC = fMCMC,
+                      Parameter = fparams)
      }
-     if(byMCMC)
-       self$metrics$byMCMC <- data.frame(MCMC = self$MCMC)
+     if(byMCMC) {
+       fMCMC <- factor(self$MCMC, levels = self$MCMC)
+       self$metrics$byMCMC <- data.frame(MCMC = fMCMC)
+     }
    },
    #' @description 
    #' Add one set of metric results
@@ -201,7 +205,8 @@ MCMCresult <- R6::R6Class(
             thisMetricList <- structure(list(thisMetric),
                                         names = thisMetricName)
           }
-          self$metrics$byMCMC <- merge(self$metrics$byMCMC, thisMetricList)
+          self$metrics$byMCMC <- merge(self$metrics$byMCMC, thisMetricList,
+                                       sort=FALSE)
         }
       }
       if(!is.null(metricResult$byParameter)) {
@@ -215,7 +220,8 @@ MCMCresult <- R6::R6Class(
                                            varnames = c('MCMC', 'Parameter'),
                                            value.name = thisMetricName)
           self$metrics$byParameter <- merge(self$metrics$byParameter,
-                                            thisTidyMetric)
+                                            thisTidyMetric,
+                                            sort=FALSE)
         }
       }
       if(!is.null(metricResult$other)) {

--- a/compareMCMCs/tests/testthat/test-dummy.R
+++ b/compareMCMCs/tests/testthat/test-dummy.R
@@ -15,3 +15,10 @@ test_that("compareMCMCs works", {
               "dummy"))
 }
 )
+
+  res <- compareMCMCs::compareMCMCs(needRmodel = FALSE,
+                                    MCMCs = c('dummy'),
+                                    monitors = paste0("x[", 1:20, "]"),
+                                    MCMCcontrol = list(niter = 2000))
+make_MCMC_comparison_pages(res, modelName = "dummy")
+browseURL(file.path(tempdir(), "dummy.html"))

--- a/compareMCMCs/tests/testthat/test-metrics.R
+++ b/compareMCMCs/tests/testthat/test-metrics.R
@@ -262,3 +262,13 @@ test_that("various metrics and comparison pages work", {
   expect_true("test model4_paceSummaryAll.jpg" %in% list.files(tempdir()))
 }
 )
+
+test_that("byParameter sort order is natural", {
+  paramNames <- paste0("x[", 1:20, "]")
+  res <- compareMCMCs::compareMCMCs(needRmodel = FALSE,
+                                    MCMCs = c('dummy'),
+                                    monitors = paramNames,
+                                    MCMCcontrol = list(niter = 2000))
+  expect_identical(as.character(res$dummy$metrics$byParameter$Parameter),
+                   paramNames)
+})


### PR DESCRIPTION
This PR ensures that the `Parameter` column of a `byParameter` data frame of an `MCMCresult$metrics` list keeps the parameters in their naturally sorted order. By default, when R converts a character vector to a factor, it sorts the elements, resulting in `x[10]`...`x[19]` coming before `x[2]`, etc. This PR sets the levels explicitly to keep the natural ordering (which comes from the monitors). This propagates to the ordering of legends and subfigures in the html comparison pages. This fixes #3.